### PR TITLE
Prevent png's to be corrupted by line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# prevent line ending corruption.
+*.png binary


### PR DESCRIPTION
Normally for git everything is a text file. Line ending changes from \r\n to \n can cause the picture to corrupt.
